### PR TITLE
aws-sdk Added

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,8 @@ RUN php composer-setup.php --install-dir=/usr/local/bin --filename=composer
 RUN apt-get update && apt-get install -y git
 RUN if [ ! -d "sdk-php" ]; then git clone --depth 1 https://github.com/ProcessMaker/sdk-php.git; fi
 
+# Get the last AWS-SDK version
+RUN apt-get install zip unzip -y
+RUN composer require aws/aws-sdk-php
+
 RUN composer install


### PR DESCRIPTION
the following lines where added to have the SDK available 

#### Get the last AWS-SDK version
RUN apt-get install zip unzip -y
RUN composer require aws/aws-sdk-php

This is related to https://github.com/ProcessMaker/docker-executor-php/issues/3

Thanks 

@alvarofloresPM 