### PR TITLE
Set aws/aws-sdk-php and phpunit versions

### DIFF
--- a/src/composer.json
+++ b/src/composer.json
@@ -1,9 +1,10 @@
 {
     "require": {
+        "aws/aws-sdk-php": "^3.192",
         "guzzlehttp/guzzle": "~6.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7",
+        "phpunit/phpunit": "^6.5.14",
         "mockery/mockery": "^1.2"
     },
     "autoload": {


### PR DESCRIPTION
When rebuilding the SDK in PHP docker, the build fails with the following error message:

```
Using version ^3.192 for aws/aws-sdk-php
./composer.json has been updated
Running composer update aws/aws-sdk-php
Loading composer repositories with package information
Updating dependencies
Your requirements could not be resolved to an installable set of packages.
  Problem 1
    - Root composer.json requires aws/aws-sdk-php ^3.192 -> satisfiable by aws/aws-sdk-php[3.192.0].
    - phpunit/php-timer 2.1.3 conflicts with aws/aws-crt-php 1.0.1.
    - phpunit/phpunit 7.5.20 requires phpunit/php-timer ^2.1 -> satisfiable by phpunit/php-timer[2.1.3].
    - aws/aws-sdk-php 3.192.0 requires aws/aws-crt-php ^1.0.1 -> satisfiable by aws/aws-crt-php[1.0.1].
    - phpunit/phpunit is locked to version 7.5.20 and an update of this package was not requested.
Installation failed, reverting ./composer.json and ./composer.lock to their original content.
The command '/bin/sh -c composer require aws/aws-sdk-php' returned a non-zero code: 2
```
`aws/aws-sdk-php` is added by the building script, but composer fails to add it.

This PR adds `aws/aws-sdk-php` to composer.json, so it could be solved with the proper `phpunit/phpunit` version.
