### PR TITLE
problems with dependencies in script executor

### DIFF
--- a/src/DockerExecutorPhpServiceProvider.php
+++ b/src/DockerExecutorPhpServiceProvider.php
@@ -23,7 +23,7 @@ class DockerExecutorPhpServiceProvider extends ServiceProvider
                 'language' => 'php',
                 'title' => 'PHP Executor',
                 'description' => 'Default PHP Executor',
-                'config' => 'RUN composer require aws/aws-sdk-php'
+                'config' => 'RUN composer require aws/aws-sdk-php:3.226.0'
             ]);
             
             // Build the instance image. This is the same as if you were to build it from the admin UI


### PR DESCRIPTION
[FOUR-6479](https://processmaker.atlassian.net/browse/FOUR-6479)
- Set version aws-sdk-php for depedencies
- need `php artisan docker-executor-php:install`
before
![image](https://user-images.githubusercontent.com/1747025/176918394-038880b0-8477-4c08-a4ee-fed7636cfb62.png)
After 
![image](https://user-images.githubusercontent.com/1747025/176919079-132025f0-7ff1-4a16-860c-23d9add8fa31.png)
