### PR TITLE
Bugfix/FOUR-7245: PDF's text is displayed as lines in PDF Generator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,12 @@ RUN php composer-setup.php --install-dir=/usr/local/bin --filename=composer
 
 RUN apt-get update && apt-get install -y git zip unzip
 
+RUN apt-get update && apt-get install -y \
+        libfreetype6-dev \
+        libjpeg62-turbo-dev \
+        libpng-dev \
+    && docker-php-ext-configure gd --with-freetype --with-jpeg \
+    && docker-php-ext-install -j$(nproc) gd
+RUN apt-get install -y libzip-dev && docker-php-ext-install zip
+
 RUN composer install


### PR DESCRIPTION
### Reproduction steps
- Create aprocess with PDF Generator
- Create a screen to PDF 
- Add a link on the rich text 
- Create a Requests
- Wait until the PDF will be generate
- Open PDF

**Note**
Make sure you install docker-executor-php, restart docker and restart horizon

**Current Behavior**
Lines are displayed instance of the text that contains a link in PDF 

**Expected Behavior**
The text with link should be displayed in PDF

### Solution
Add libraries to fix link issue showing lines and empty text

**Working video**

https://user-images.githubusercontent.com/90727999/211079260-45cafd9d-a288-48e4-b4c6-7884d6abca17.mov


### Related Ticket
- [FOUR-7245](https://processmaker.atlassian.net/browse/FOUR-7245)


[FOUR-7245]: https://processmaker.atlassian.net/browse/FOUR-7245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ