### PR TITLE
Update version of phpunit to run in php v7 and v8

### DIFF
--- a/src/composer.json
+++ b/src/composer.json
@@ -4,7 +4,7 @@
         "guzzlehttp/guzzle": "~6.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.5.14",
+        "phpunit/phpunit": "*",
         "mockery/mockery": "^1.2"
     },
     "autoload": {


### PR DESCRIPTION
Update phpunit to run in php v7 and v8, required to be used in nayra-docker executor.
This PR keeps compatibility with previous versios of php.

## Related ticket
- https://processmaker.atlassian.net/browse/FOUR-8555
