### PR TITLE
FOUR-19612 update php docker base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.2.8-cli-stretch
+FROM php:7.3.33-cli-buster
 
 # Copy over our PHP libraries/runtime
 COPY ./src /opt/executor
@@ -10,7 +10,8 @@ WORKDIR /opt/executor
 RUN curl -sS https://getcomposer.org/installer -o composer-setup.php
 RUN php composer-setup.php --install-dir=/usr/local/bin --filename=composer
 
-RUN echo "deb http://archive.debian.org/debian stretch main" > /etc/apt/sources.list
+RUN echo "deb https://archive.debian.org/debian buster main" > /etc/apt/sources.list
+
 RUN apt-get update && apt-get install -y git zip unzip
 
 RUN composer install


### PR DESCRIPTION
Update the Dockerfile base image to PHP 7.3 and change Debian source to Buster

## Related ticket
[FOUR-19612](https://processmaker.atlassian.net/browse/FOUR-19612)

[FOUR-19612]: https://processmaker.atlassian.net/browse/FOUR-19612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ