### PR TITLE
FOUR-31789: Add streaming tar entrypoint for PHP script executor

### DIFF
--- a/src/run-stream.sh
+++ b/src/run-stream.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+
+tar xf - -C /
+
+php /opt/executor/bootstrap.php
+
+if [ "$#" -gt 0 ]; then
+    tar cf - -C / "$@"
+fi


### PR DESCRIPTION
## Summary

- Adds `src/run-stream.sh`, a streaming entrypoint that accepts script task inputs via stdin (tar archive), runs `bootstrap.php`, and optionally returns output files via stdout (tar archive).
- Enables Docker API–driven execution without bind mounts, complementing the existing volume-mount workflow documented in the README.

## Context

Today the PHP executor is invoked directly:

```bash
docker run ... processmaker/executor:php php /opt/executor/bootstrap.php
```
The new script supports a pipe-based flow suitable for callers that inject files over stdin/stdout instead of mounting host paths:

Caller sends a tar of `data.json`, `config.json`, `script.php`, and an empty `output.json` on stdin.
Container extracts to /, executes the script via `bootstrap.php`.
Caller receives `output.json` (and any other requested paths) from stdout.